### PR TITLE
Allow no index

### DIFF
--- a/src/main/scala/org/clulab/reading/CorpusReader.scala
+++ b/src/main/scala/org/clulab/reading/CorpusReader.scala
@@ -63,7 +63,7 @@ class CorpusReader(
   consolidateByLemma: Boolean,
 ) {
 
-  lazy val proc = new FastNLPProcessor
+  var proc: Option[Processor] = None
 
 // todo: remove the query box from the UI
   /**
@@ -141,9 +141,11 @@ class CorpusReader(
 
   private def convertToLemmas(words: Seq[String]): Seq[String] = {
     val s = words.mkString(" ")
-    val doc = proc.mkDocument(s)
-    proc.tagPartsOfSpeech(doc)
-    proc.lemmatize(doc)
+    assert(proc.isDefined, "The CorpusReader processor wasn't initialized")
+    val processor = proc.get
+    val doc = processor.mkDocument(s)
+    processor.tagPartsOfSpeech(doc)
+    processor.lemmatize(doc)
     doc.clear()
     val sentence = doc.sentences.head
     // return the lemmas

--- a/src/main/scala/org/clulab/reading/TextReader.scala
+++ b/src/main/scala/org/clulab/reading/TextReader.scala
@@ -37,6 +37,7 @@ class TextReader(val proc: Processor, val rules: String) {
     val odinsonDocument = ProcessorsUtils.convertDocument(procDoc)
     val ee = mkExtractorEngine(odinsonDocument)
     val reader = new CorpusReader(ee, numEvidenceDisplay, consolidateByLemma)
+    reader.proc = Some(proc)
     reader.extractMatchesFromRules(rules)
   }
 

--- a/webapp/app/controllers/HomeController.scala
+++ b/webapp/app/controllers/HomeController.scala
@@ -126,12 +126,5 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
     val jsonMatches = JsonUtils.asJsonArray(matchesAsJsonStrings(matches))
     Ok(jsonMatches)
   }
-
-  def index(): Action[AnyContent] = Action { request =>
-    val data = request.body.asJson.get.toString()
-    val j = ujson.read(data)
-
-  }
-
-
+  
 }

--- a/webapp/app/controllers/HomeController.scala
+++ b/webapp/app/controllers/HomeController.scala
@@ -5,6 +5,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 
 import javax.inject._
+import org.clulab.processors.fastnlp.FastNLPProcessor
 import org.clulab.reading.{CorpusReader, DependencySearcher, Match, RuleBuilder, TextReader}
 import org.clulab.reading.Consolidator._
 import org.clulab.reading.CorpusReader._
@@ -20,13 +21,12 @@ import play.api.mvc._
 class HomeController @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
 
   // -------------------------------------------------
-  println("CorpusReader is getting started ...")
-  val reader = CorpusReader.fromConfig
-  val proc = reader.proc
+  lazy val reader = CorpusReader.fromConfig
+  lazy val proc = new FastNLPProcessor()
   lazy val ruleBuilder = new RuleBuilder()
   lazy val nmodSearcher = new DependencySearcher
-  println("CorpusReader is ready to go ...")
   // -------------------------------------------------
+  def initializeCorpusReader(): Unit = if (reader.proc.isEmpty) reader.proc = Some(proc)
 
   /**
    * Create an Action to render an HTML page.
@@ -37,10 +37,12 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
    */
 
   def dev() = Action { implicit request: Request[AnyContent] =>
+    initializeCorpusReader()
     Ok(views.html.dev())
   }
 
   def simple() = Action { implicit request: Request[AnyContent] =>
+    initializeCorpusReader()
     Ok(views.html.simple())
   }
 
@@ -64,7 +66,6 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
   }
 
   def buildRules(data:String) = Action {
-    println(data)
     // todo: making an Obj in two places now... refactor?
     val j = ujson.read(data)
     val ruleName = j.obj.get("ruleName").map(_.str).getOrElse("NO_NAME")

--- a/webapp/app/controllers/HomeController.scala
+++ b/webapp/app/controllers/HomeController.scala
@@ -4,6 +4,7 @@ import java.io.PrintWriter
 import java.text.SimpleDateFormat
 import java.util.Date
 
+import ai.lum.common.ConfigFactory
 import javax.inject._
 import org.clulab.processors.fastnlp.FastNLPProcessor
 import org.clulab.reading.{CorpusReader, DependencySearcher, Match, RuleBuilder, TextReader}
@@ -25,6 +26,7 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
   lazy val proc = new FastNLPProcessor()
   lazy val ruleBuilder = new RuleBuilder()
   lazy val nmodSearcher = new DependencySearcher
+  println("OdinsonWebapp is ready to go ...")
   // -------------------------------------------------
   def initializeCorpusReader(): Unit = if (reader.proc.isEmpty) reader.proc = Some(proc)
 
@@ -124,5 +126,12 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
     val jsonMatches = JsonUtils.asJsonArray(matchesAsJsonStrings(matches))
     Ok(jsonMatches)
   }
+
+  def index(): Action[AnyContent] = Action { request =>
+    val data = request.body.asJson.get.toString()
+    val j = ujson.read(data)
+
+  }
+
 
 }


### PR DESCRIPTION
- allow users to not specify an index when only using process_text endpoint
- switch to a partial annotation to speed up parsing time

fyi @brandomr 