### PR TITLE
reconfigure the compile/package/Docker build lifecycle to streamline building and running the application

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*
+!webapp/target/universal/*

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.json
 
 .idea/
-target/*
+target
 project/project
 project/target
+
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8
 
-ENV APP_DIR /opt/app
+ENV APP_DIR /opt/odinson
 
 RUN apt-get --assume-yes update && \
     mkdir /opt/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,16 @@
-FROM ysihaoy/scala-play:2.12.2-2.6.0-sbt-0.13.15
+FROM openjdk:8
 
-# Install Odinson
-RUN apk --no-cache add git
-RUN git clone https://github.com/lum-ai/odinson /tmp/odinson
-RUN cd /tmp/odinson && \
-  sbt publishLocal
+ENV APP_DIR /opt/app
 
+RUN apt-get --assume-yes update && \
+    mkdir /opt/app
 
-# caching dependencies
-COPY ["build.sbt", "/tmp/build/"]
-COPY ["project/plugins.sbt", "project/build.properties", "/tmp/build/project/"]
-RUN cd /tmp/build && \
-  sbt compile && \
-  sbt test:compile && \
- rm -rf /tmp/build
+WORKDIR $APP_DIR
 
-# copy code
-COPY . /root/webapp
-WORKDIR /root/webapp
+COPY ./webapp/target/universal/webapp*.zip $APP_DIR/app.zip
 
-EXPOSE 9000
-CMD sbt webapp/run
+RUN unzip -q $APP_DIR/app.zip && \
+    export APP=$(ls -d */ | grep webapp) && \
+    mv $APP app
+
+ENTRYPOINT $APP_DIR/app/bin/webapp

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ with the local datetime (e.g., `example-rule_2020-04-08_10:47:36.jsonl`).
 You can build this into a container with:
 
 ```
+sbt "project webapp" "dist"
 docker build -t odinsonwebapp .
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,6 @@
 import sbt._
-
-name := "OdinsonWebapp"
 organization in ThisBuild := "org.clulab"
+name := "OdinsonWebapp"
 
 scalaVersion in ThisBuild := "2.12.4"
 
@@ -30,25 +29,3 @@ lazy val webapp = project
   .enablePlugins(PlayScala, JavaAppPackaging, SbtNativePackager)
   .aggregate(core)
   .dependsOn(core)
-  .settings(
-    assemblyMergeStrategy in assembly := {
-      case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard
-      case PathList("META-INF", "*.SF")        => MergeStrategy.discard
-      case PathList("META-INF", "*.DSA")       => MergeStrategy.discard
-      case PathList("META-INF", "*.RSA")       => MergeStrategy.discard
-      case PathList("META-INF", "*.DEF")       => MergeStrategy.discard
-      case PathList("*.SF")                    => MergeStrategy.discard
-      case PathList("*.DSA")                   => MergeStrategy.discard
-      case PathList("*.RSA")                   => MergeStrategy.discard
-      case PathList("*.DEF")                   => MergeStrategy.discard
-      case PathList("META-INF", "services", "org.apache.lucene.codecs.PostingsFormat" ) => MergeStrategy.filterDistinctLines
-      case PathList("META-INF", "services", "com.fasterxml.jackson.databind.Module" ) => MergeStrategy.filterDistinctLines
-      case PathList("META-INF", "services", "javax.xml.transform.TransformerFactory" ) => MergeStrategy.first // or last or both?
-      case PathList("reference.conf")   => MergeStrategy.concat
-      case PathList("application.conf") => MergeStrategy.concat // combine config files
-      case PathList("logback.xml")      => MergeStrategy.first
-      case _                            => MergeStrategy.last
-    },
-    test in assembly := {},
-    Compile / unmanagedResourceDirectories += baseDirectory.value / "webapp" / "conf"
-  )

--- a/build.sbt
+++ b/build.sbt
@@ -1,24 +1,54 @@
-name := "OdinsonWebapp"
-organization := "org.clulab"
+import sbt._
 
-resolvers +=  "Artifactory" at "http://artifactory.cs.arizona.edu:8081/artifactory/sbt-release" // processors-models
+name := "OdinsonWebapp"
+organization in ThisBuild := "org.clulab"
+
+scalaVersion in ThisBuild := "2.12.4"
+
+resolvers ++= Seq(
+  "Artifactory" at "http://artifactory.cs.arizona.edu:8081/artifactory/sbt-release", // processors-models
+  "Local Ivy Repository" at s"file://${System.getProperty("user.home")}/.ivy2/local/default"
+)
 
 val procVer = "8.2.3"
 val odinsonVer = "0.3.0-SNAPSHOT"
 
 libraryDependencies ++= Seq(
-  "org.clulab"    %% "processors-main"          % procVer,
-  "org.clulab"    %% "processors-corenlp"       % procVer,
-  "ai.lum"        %% "odinson-core"             % odinsonVer,
-  "ai.lum"        %% "odinson-extra"            % odinsonVer,
-  "ai.lum"        %% "common"                   % "0.0.10",
-  "com.lihaoyi"   %% "ujson"                    % "0.7.1",
-  "com.lihaoyi"   %% "upickle"                  % "0.7.1",
+  "org.clulab" %% "processors-main" % procVer,
+  "org.clulab" %% "processors-corenlp" % procVer,
+  "ai.lum" %% "odinson-core" % odinsonVer,
+  "ai.lum" %% "odinson-extra" % odinsonVer,
+  "ai.lum" %% "common" % "0.0.10",
+  "com.lihaoyi" %% "ujson" % "0.7.1",
+  "com.lihaoyi" %% "upickle" % "0.7.1",
+  guice
 )
 
-lazy val core = project in file(".")
+lazy val core = (project in file(".")).disablePlugins(PlayScala, JavaAppPackaging, SbtNativePackager)
 
 lazy val webapp = project
-  .enablePlugins(PlayScala)
+  .enablePlugins(PlayScala, JavaAppPackaging, SbtNativePackager)
   .aggregate(core)
   .dependsOn(core)
+  .settings(
+    assemblyMergeStrategy in assembly := {
+      case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard
+      case PathList("META-INF", "*.SF")        => MergeStrategy.discard
+      case PathList("META-INF", "*.DSA")       => MergeStrategy.discard
+      case PathList("META-INF", "*.RSA")       => MergeStrategy.discard
+      case PathList("META-INF", "*.DEF")       => MergeStrategy.discard
+      case PathList("*.SF")                    => MergeStrategy.discard
+      case PathList("*.DSA")                   => MergeStrategy.discard
+      case PathList("*.RSA")                   => MergeStrategy.discard
+      case PathList("*.DEF")                   => MergeStrategy.discard
+      case PathList("META-INF", "services", "org.apache.lucene.codecs.PostingsFormat" ) => MergeStrategy.filterDistinctLines
+      case PathList("META-INF", "services", "com.fasterxml.jackson.databind.Module" ) => MergeStrategy.filterDistinctLines
+      case PathList("META-INF", "services", "javax.xml.transform.TransformerFactory" ) => MergeStrategy.first // or last or both?
+      case PathList("reference.conf")   => MergeStrategy.concat
+      case PathList("application.conf") => MergeStrategy.concat // combine config files
+      case PathList("logback.xml")      => MergeStrategy.first
+      case _                            => MergeStrategy.last
+    },
+    test in assembly := {},
+    Compile / unmanagedResourceDirectories += baseDirectory.value / "webapp" / "conf"
+  )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,2 @@
-resolvers += "Typesafe Plugins" at "https://repo.typesafe.com/typesafe/releases/"
-
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.6")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.0")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,5 @@
+resolvers += "Typesafe Plugins" at "https://repo.typesafe.com/typesafe/releases/"
+
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.6")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")

--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -1,8 +1,0 @@
-logs
-target
-/.idea
-/.idea_modules
-/.classpath
-/.project
-/.settings
-/RUNNING_PID

--- a/webapp/build.sbt
+++ b/webapp/build.sbt
@@ -1,10 +1,4 @@
-name := """webapp"""
-scalaVersion := "2.12.4"
-
-libraryDependencies ++= Seq(
-  guice,
-  "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test
-)
+name := "webapp"
 
 // Adds additional packages into Twirl
 //TwirlKeys.templateImports += "org.clulab.controllers._"

--- a/webapp/conf/application.conf
+++ b/webapp/conf/application.conf
@@ -1,3 +1,4 @@
+play.http.secret.key="aI:bA>LGlTZ4_CTbZVwMGE771FIiuG[2fv/=BsFy=7G1SGA=OSNGK:Kzr5W^Ij3/"
 # Security Filter Configuration - Content Security Policy
 play.filters.headers {
   contentSecurityPolicy = "default-src 'self' blob:;"

--- a/webapp/project/build.properties
+++ b/webapp/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.2
+sbt.version = 1.4.5


### PR DESCRIPTION
TwoSix would like to host the OdinsonWebapp internally as a service. However, the build as it stands now is a little funky because it builds the application from scratch as part of the startup and requires SBT to run the application. Here we are proposing some changes that will streamline the build/package lifecycle and cut down on the number of dependencies required to run the application.

Here are the key changes we are proposing with this PR:

1. Remove the dependency on `ysihaoy/scala-play:2.12.2-2.6.0-sbt-0.13.15` Docker image because it has a lot of extra unnecessary stuff. Instead, we run on a bare minimum Java 8 OpenJDK image to cut down on image size
2. Change the application packaging to use the `sbt-native-packager` plugin to package the application as a standard zip file. This is a very common way of packaging Scala/Java applications in a portable way
3. Add only the application and its dependencies to the Docker image
4. Consolidate build information in `build.sbt` files to reduce redundant configuration
5. Clean up the Git index vis a vis `.gitignore` to remove `target` directories and other build artifacts
6. Introduce `.dockerignore` to make the Docker build context smaller and speed up the Docker build

One important thing to note here is that we have not touched any of the functionality of the application itself. We've only made changes to project configuration and build files

