### PR TITLE
clear state from prev queries

### DIFF
--- a/src/main/scala/org/clulab/reading/CorpusReader.scala
+++ b/src/main/scala/org/clulab/reading/CorpusReader.scala
@@ -90,6 +90,7 @@ class CorpusReader(
    */
   def extractMatches(extractors: Seq[Extractor]): Seq[Match] = {
     val mentions = extractorEngine.extractMentions(extractors).toArray
+    extractorEngine.clearState()
     // Convert the mentions into our Match objects
     getMatches(mentions)
   }


### PR DESCRIPTION
Fixes a bug where the state wasn't being cleared (from the update to Odinson 0.3.1), making the results table not see to refresh.

FYI @brandomr @dvzhang @reynoldsm88